### PR TITLE
bug/ID-20/When-entering-to-profile-info-screen-after-sign-up-with-google-CI-field-is-filled-with-a-too-large-number

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.js
+++ b/src/app/api/auth/[...nextauth]/route.js
@@ -53,7 +53,7 @@ const authOptions = NextAuth({
               }
             } else {
               const newUser = {
-                ci: profile.sub,
+                ci: 'N/A',
                 name: profile.name.split(' ')[0],
                 lastName: profile.name.split(' ').slice(1).join(' ') || 'No lastname',
                 email: user.email,


### PR DESCRIPTION
**What did I do?**
- I solved the bug reported by the test, which was a long number showing on user profile.

**How did I do it?**
- Changing the parameter when a google account is saved.

**Why did I do it?**
- To the user don't get a confused when see her CI or DNI.

**Author:** @Misax148 
**Reviewers:** @denisgandel @Karvlox 

**Link | Click Up | Bug :** https://sharing.clickup.com/9011140495/t/h/8686ezy90/0G52Q1R8HUZD77R
**QA - TEST**: Juan Carlos Hidalgo - AntWood 